### PR TITLE
Documenting incompatibility with widely used linum-mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Requirements
 ------------
 
 - Emacs 24.4
+- If you use (n)linum-mode, you must disable it for buffer with
+  olivetti-mode, or left margin will not be displayed.
 
 Installation
 ------------


### PR DESCRIPTION
I've spent about a hour trying to understand why left margin is not displayed and text left uncentered. Probably not just me will face this problem.