### PR TITLE
Make it easier to adjust olivetti-body-width

### DIFF
--- a/olivetti.el
+++ b/olivetti.el
@@ -253,7 +253,11 @@ If prefixed with ARG, incrementally decrease."
                    (+ olivetti-body-width (* 0.01 p))))))
     (setq olivetti-body-width (olivetti-safe-width n)))
   (olivetti-set-environment)
-  (message "Text body width set to %s" olivetti-body-width))
+  (message "Text body width set to %s" olivetti-body-width)
+  (set-temporary-overlay-map
+   (let ((map (make-sparse-keymap)))
+     (define-key map "]" 'olivetti-expand)
+     (define-key map "[" 'olivetti-shrink) map)))
 
 (defun olivetti-shrink (&optional arg)
   "incrementally decrease the value of `olivetti-body-width'.


### PR DESCRIPTION
When invoking `olivetti-expand` let `[` and `]` be used to make further
adjustments (not unlike `text-scale-mode`).

I'm not sure if you want to merge this, but it is at least something I find useful!