### PR TITLE
Fixed olivetti-scale-width for integer heights

### DIFF
--- a/olivetti.el
+++ b/olivetti.el
@@ -275,11 +275,15 @@ instead `olivetti-set-mode-line'."
 
 For compatibility with `text-scale-mode', if
 `face-remapping-alist' includes a :height property on the default
-face, scale N by that factor, otherwise scale by 1."
-  (* n (or (plist-get (cadr (assq 'default
-                                  face-remapping-alist))
-                      :height)
-           1)))
+face, scale N by that factor if it is a fraction, by (height/100)
+if it is an integer, and otherwise scale by 1."
+  (let
+      ((height (plist-get (cadr (assq 'default face-remapping-alist)) :height)))
+    (cond
+     ((integerp height) (* n (/ height 100.0)))
+     ((floatp height) (* n height))
+     (t n))))
+
 
 (defun olivetti-safe-width (width window)
   "Parse WIDTH to a safe value for `olivetti-body-width' for WINDOW.


### PR DESCRIPTION
The function `olivetti-scale-width` incorrectly assumes that the height is
always a fraction. However, it can in very normal circumstances be an integer
such as 120 (see [section 39.12.1 from the manual](https://www.gnu.org/software/emacs/manual/html_node/elisp/Face-Attributes.html)).
In such a case, the old function scales the width by a number that is far too
large, which results in margins of width 0.

To see how this fails, set the height to something like 120 by using, for
example, buffer-face-mode, e.g., run this code:
```
(defun my-buffer-face-mode ()
  (interactive)
  (setq buffer-face-mode-face
        '(:height 120))
  (buffer-face-mode 1))
  
(my-buffer-face-mode)
(olivetti-mode 1)
```

I fixed this by scaling by height/100 if the height is an integer. If it is a
float or something else entirely, the new function behaves as the old.

---

I'm not sure if dividing an integer height by 100 is exactly the right behaviour (I don't fully understand the necessity of the scaling in the first place), but it works for my use cases.