### PR TITLE
Improved code style for mode-map

### DIFF
--- a/olivetti.el
+++ b/olivetti.el
@@ -314,12 +314,13 @@ If prefixed with ARG, incrementally increase."
 
 ;;; Keymap
 
-(defvar olivetti-mode-map (make-sparse-keymap)
+(defvar olivetti-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c }") #'olivetti-expand)
+    (define-key map (kbd "C-c {") #'olivetti-shrink)
+    (define-key map (kbd "C-c \\") #'olivetti-set-width)
+    map)
   "Mode map for `olivetti-mode'.")
-
-(define-key olivetti-mode-map (kbd "C-c }") #'olivetti-expand)
-(define-key olivetti-mode-map (kbd "C-c {") #'olivetti-shrink)
-(define-key olivetti-mode-map (kbd "C-c \\") #'olivetti-set-width)
 
 
 ;;; Mode Definition


### PR DESCRIPTION
This is how mode-maps are usually defined in packages in emacs. This is so that the user can assign a map before requiring the mode and not have their maps be overriden. Previously, if you defined your keys outside of a with-eval-after-load and before olivett-mode the 3 keys this package defined would be appended onto olivetti-mode-map.