### PR TITLE
Fix URL field.

### DIFF
--- a/olivetti.el
+++ b/olivetti.el
@@ -8,7 +8,7 @@
 ;; Keywords: wp, text
 ;; Version: 1.11.0-beta
 ;; Package-Requires: ((emacs "24.5"))
-;; URL: https://gthub.com/rnkn/olivetti
+;; URL: https://github.com/rnkn/olivetti
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
I'm creating some tooling that analyses Elisp package metadata and noticed the URL field for this package had a typo.