### PR TITLE
Fix for when fringe-mode is Void in terminal

### DIFF
--- a/olivetti.el
+++ b/olivetti.el
@@ -275,9 +275,10 @@ if it is an integer, and otherwise return WIDTH."
   "Remove Olivetti's parameters and margins from WINDOW."
   (when (eq (window-parameter window 'split-window) 'olivetti-split-window)
     (set-window-parameter window 'split-window nil))
-  (if (consp fringe-mode)
-      (set-window-fringes window (car fringe-mode) (cdr fringe-mode))
-    (set-window-fringes window fringe-mode fringe-mode))
+  (when (featurep 'fringe)
+    (if (consp fringe-mode)
+        (set-window-fringes window (car fringe-mode) (cdr fringe-mode))
+      (set-window-fringes window fringe-mode fringe-mode)))
   (set-window-margins window nil))
 
 (defun olivetti-reset-all-windows ()


### PR DESCRIPTION
In terminal, `olivetti-mode` does not start, at least on Windows because `fringe-mode` is Void.
This change will fix that by checking that it is set before running `set-window-fringes`.