### PR TITLE
Enable setting olivetti-body-width relative to fill-column

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ Features
 
  - Set a desired text body width to automatically resize window margins
    to keep the text comfortably in the middle of the window.
- - Text body width can be the number of characters (an integer), a fraction of
-   the window width (a float between 0.0 and 1.0), or `nil` which uses the value
-   of `fill-column` +2.
+ - Text body width can be the number of characters (a positive nonzero
+   integer), a fraction of the window width (a float between 0.0 and
+   1.0) or a negative or zero integer, which uses the value of
+   `fill-column` plus the absolute value of that number. `nil` acts as -2
+   (so, `fill-column` +2) for backwards compatibility.
  - Interactively change body width with:  
    `olivetti-shrink C-c { { { ...`  
    `olivetti-expand C-c } } } ...`  


### PR DESCRIPTION
I think it would be useful to be able to specify `olivetti-body-width` as relative to the value of `fill-column` without using hooks.
This pull-request enables it trough negative numbers: by setting `olivetti-body-width` to a negative integer, the actual size of the window gets set to `fill-column` plus the absolute value of `olivetti-body-width`.
This has also the added benefit of being fully backwards compatible.

I can think of two possible use-cases for this:

1. Adjusting for line numbers
2. Adjusting for `org-mode` indents and headers