### PR TITLE
Add Auto-Olivetti mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ Variable:
 See `(info "(emacs) File Variables")`
 
 
+To automatically enable `olivetti-mode' for certain file modes, customize
+`auto-olivetti-enabled-modes' and activate `auto-olivetti-mode':
+
+    (setq-default auto-olivetti-enabled-modes '(text-mode prog-mode))
+    (auto-olivetti-mode)
+
 Alternatives
 ------------
 

--- a/olivetti.el
+++ b/olivetti.el
@@ -507,7 +507,7 @@ body width set with `olivetti-body-width'."
 
 (defgroup auto-olivetti nil
   "Automatically enable `olivetti-mode' in wide windows."
-  :group 'olivetti-mode
+  :group 'olivetti
   :prefix "auto-olivetti-")
 
 (defcustom auto-olivetti-enabled-modes '(text-mode)


### PR DESCRIPTION
Hi there!

I threw together a [little package](https://sr.ht/~ashton314/auto-olivetti/) to automatically enable `olivetti-mode` when certain major modes were activated. Thanks to some [discussion on the Emacs subreddit](https://www.reddit.com/r/emacs/comments/13pts6v/new_package_autoolivettiautomatically_turn_on/) I decided to suggest this package instead as an extension of `olivetti-mode`.

I've added `auto-olivetti` to the bottom of `olivetti`, as it's pretty self-contained. Please let me know what you think.