### PR TITLE
Prevent olivetti-mode initialization failure in terminal

### DIFF
--- a/olivetti.el
+++ b/olivetti.el
@@ -427,7 +427,9 @@ If prefixed with ARG, incrementally increase."
     (define-key map [left-fringe mouse-1] #'mouse-set-point)
     (define-key map [right-fringe mouse-1] #'mouse-set-point)
     ;; This code is taken from https://github.com/joostkremers/visual-fill-column
-    (when (bound-and-true-p mouse-wheel-mode)
+    (when (and (bound-and-true-p mouse-wheel-mode)
+               (boundp 'mouse-wheel-down-event)
+               (boundp 'mouse-wheel-up-event))
       (define-key map (vector 'left-margin 'mouse-wheel-down-event) 'mwheel-scroll)
       (define-key map (vector 'left-margin 'mouse-wheel-up-event) 'mwheel-scroll)
       (define-key map (vector 'right-margin 'mouse-wheel-down-event) 'mwheel-scroll)


### PR DESCRIPTION
I have run into a situation where terminal Emacs has `mouse-wheel-mode` enabled but `mouse-wheel-down-event` and `mouse-wheel-up-event` are not defined. This change was necessary for Olivetti mode to start up without failure in that case.