### PR TITLE
Restore default margins upon reset

### DIFF
--- a/olivetti.el
+++ b/olivetti.el
@@ -284,7 +284,7 @@ if it is an integer, and otherwise return WIDTH."
   (if (consp fringe-mode)
       (set-window-fringes window (car fringe-mode) (cdr fringe-mode))
     (set-window-fringes window fringe-mode fringe-mode))
-  (set-window-margins window nil))
+  (set-window-margins window left-margin-width right-margin-width))
 
 (defun olivetti-reset-all-windows ()
   "Call `olivetti-reset-window' on all windows."


### PR DESCRIPTION
Currently, the function `olivetti-reset-window` unconditionally disables margins. This causes, among other issues, margin configuration to be forgotten upon entering and leaving `olivetti-mode`. There is a simple fix: since the function `set-window-margins` does not touch the buffer-local variables `{left,right}-margin-width`, we simply reset the margins to those values.