### PR TITLE
Do not assume that the default margin widths are zero

### DIFF
--- a/olivetti.el
+++ b/olivetti.el
@@ -265,9 +265,11 @@ if it is an integer, and otherwise return WIDTH."
 
 (defun olivetti-normalize-width (width window)
   "Parse WIDTH to a safe pixel value for `olivetti-body-width' for WINDOW."
-  (let ((char-width (frame-char-width (window-frame window)))
-        (window-width-pix (window-body-width window t))
-        min-width-pix)
+  (let* ((char-width (frame-char-width (window-frame window)))
+         (window-width-pix (+ (window-body-width window t)
+                              (* char-width
+                                 (+ left-margin-width right-margin-width))))
+         min-width-pix)
     (setq min-width-pix (* char-width
                            (+ olivetti-minimum-body-width
                               (% olivetti-minimum-body-width 2))))
@@ -283,7 +285,7 @@ if it is an integer, and otherwise return WIDTH."
   (if (consp fringe-mode)
       (set-window-fringes window (car fringe-mode) (cdr fringe-mode))
     (set-window-fringes window fringe-mode fringe-mode))
-  (set-window-margins window nil))
+  (set-window-margins window left-margin-width right-margin-width))
 
 (defun olivetti-reset-all-windows ()
   "Call `olivetti-reset-window' on all windows."
@@ -324,10 +326,12 @@ window."
         ;; `fill-column'
         (when (null olivetti-body-width)
           (setq olivetti-body-width (+ fill-column 2)))
-        (let ((char-width-pix   (frame-char-width (window-frame window-or-frame)))
-              (window-width-pix (window-body-width window-or-frame t))
-              (safe-width-pix   (olivetti-normalize-width
-                                 olivetti-body-width window-or-frame)))
+        (let* ((char-width-pix   (frame-char-width (window-frame window-or-frame)))
+               (window-width-pix (+ (window-body-width window-or-frame t)
+                                    (* char-width-pix
+                                       (+ left-margin-width right-margin-width))))
+               (safe-width-pix   (olivetti-normalize-width
+                                  olivetti-body-width window-or-frame)))
           ;; Handle possible display of fringes
           (when (and window-system olivetti-style)
             (let ((fringe-total (- (window-pixel-width window-or-frame)
@@ -350,11 +354,11 @@ window."
             (setq left-margin  (max (round (/ (- margin-total-pix
                                                  (car fringes))
                                               char-width-pix))
-                                    0)
+                                    left-margin-width)
                   right-margin (max (round (/ (- margin-total-pix
                                                  (cadr fringes))
                                               char-width-pix))
-                                    0))
+                                    right-margin-width))
             ;; Finally set the margins
             (set-window-margins window-or-frame left-margin right-margin)))
         ;; Set remaining window parameters

--- a/olivetti.el
+++ b/olivetti.el
@@ -263,20 +263,23 @@ if it is an integer, and otherwise return WIDTH."
       (setq height (/ height 100.0)))
     (round (* width (or height 1)))))
 
+(defun olivetti-window-width (window)
+  "Return the pixel width of WINDOW, including default margins."
+  (+ (window-body-width window t)
+     (* (frame-char-width (window-frame window))
+        (+ left-margin-width right-margin-width))))
+
 (defun olivetti-normalize-width (width window)
   "Parse WIDTH to a safe pixel value for `olivetti-body-width' for WINDOW."
   (let* ((char-width (frame-char-width (window-frame window)))
-         (window-width-pix (+ (window-body-width window t)
-                              (* char-width
-                                 (+ left-margin-width right-margin-width))))
-         min-width-pix)
-    (setq min-width-pix (* char-width
+         (window-width-pix (olivetti-window-width window))
+         (min-width-pix (* char-width
                            (+ olivetti-minimum-body-width
-                              (% olivetti-minimum-body-width 2))))
-     (if (floatp width)
-         (floor (max min-width-pix (* window-width-pix (min width 1.0))))
-       (olivetti-scale-width
-        (max min-width-pix (min (* width char-width) window-width-pix))))))
+                              (% olivetti-minimum-body-width 2)))))
+    (if (floatp width)
+        (floor (max min-width-pix (* window-width-pix (min width 1.0))))
+      (olivetti-scale-width
+       (max min-width-pix (min (* width char-width) window-width-pix))))))
 
 (defun olivetti-reset-window (window)
   "Remove Olivetti's parameters and margins from WINDOW."
@@ -327,9 +330,7 @@ window."
         (when (null olivetti-body-width)
           (setq olivetti-body-width (+ fill-column 2)))
         (let* ((char-width-pix   (frame-char-width (window-frame window-or-frame)))
-               (window-width-pix (+ (window-body-width window-or-frame t)
-                                    (* char-width-pix
-                                       (+ left-margin-width right-margin-width))))
+               (window-width-pix (olivetti-window-width window-or-frame))
                (safe-width-pix   (olivetti-normalize-width
                                   olivetti-body-width window-or-frame)))
           ;; Handle possible display of fringes


### PR DESCRIPTION
Hey Paul, when setting/resetting margin widths Olivetti currently assumes that the default values of `left-margin-width` and `right-margin-width` are zero. This assumption was partly removed after #78 in 1690a3c2779a5e5f6497c530a3bd12d33308b692, but we forgot to account for the two other places where the same assumption is made. Those places result in more subtle bugs than the previous one, so I've only recently noticed a problem. When the current window is not wide enough and Olivetti is active (not necessarily in the current window), margins are set to zero instead of their default values. This PR fixes that.

**EDIT 1:** I apparently forgot the mistake I made in #78 and incorporated the same change here. I'll try to see how to calculate the additional width correctly without assuming that `olivetti-reset-window` sets the margin widths to zero.

**EDIT 2:** I've changed the functions `olivetti-normalize-width` and `olivetti-set-window` to compute the window's width in pixels by taking the margins into account. If the default margin widths are zero, nothing changes from before; otherwise, margins are treated as if they are part of the window's text area (while fringes, vertical dividers, or scroll bars are still excluded). In my testing this results in the same behavior as before while also respecting the default margin widths.